### PR TITLE
 Change the color of button outline after hovering

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -77,6 +77,7 @@ button, .btn, .btn-outlined {
 
 button:hover, .btn:hover, .btn-outlined:hover {
   transform: translateY(-3px);
+  border-color: #0764af;
 }
 
 .btn {


### PR DESCRIPTION
When we hover over the get-start button the outline of its border will change color.