### PR TITLE
Fixed the Typo in the main landing page of the site.

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
       <div class="con-1 flex">
         <div class="top-1-left flex-c">
           <div class="top-1-left-heading">
-            <h1 class="heading-56">Wecome to E-Cell IIT Mandi</h1>
+            <h1 class="heading-56">Welcome to E-Cell IIT Mandi</h1>
           </div>
           <div class="top-1-details">
             The Entrepreneurship Cell (ECell) at IIT Mandi cultivates entrepreneurship, innovation, and leadership skills 


### PR DESCRIPTION
"Wecome to E-Cell IIT mandi" to "Welcome to E-Cell IIT Mandi"
